### PR TITLE
Fix byte-compile warning

### DIFF
--- a/dilbert.el
+++ b/dilbert.el
@@ -135,7 +135,7 @@ Should preferably be located in `dilbert-cache-dir'."
 	  (message "%s" url))))
 
 ;;;###autoload
-(defalias #'dilbert #'dilbert-view-latest)
+(defalias 'dilbert #'dilbert-view-latest)
 
 ;;;; Functions
 


### PR DESCRIPTION
```
dilbert.el:138:13: Warning: the function ‘dilbert’ is not known to be defined.
```